### PR TITLE
FLUID-5795: Standard builds will publish a version control tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fluid-publish
 
 __value__: true (Boolean)
 
-Specifies that a standard release should be generated. This creates a release named after the version in the package.json file. It will not increase the version number.
+Specifies that a standard release should be generated. This creates a release named after the version in the package.json file. It will not increase the version number. However, it will create a tag and publish this tag to the version control system.
 
 ```bash
 # creates a standard release
@@ -90,7 +90,7 @@ publish.dev();
 
 #### `standard` ####
 
-Publishes a release build. This creates a release named after the version in the package.json file. By default it will not increase the version number, this must be done separately.
+Publishes a release build. This creates a release named after the version in the package.json file. By default it will not increase the version number, this must be done separately. However, it will create a tag and publish this tag to the version control system.
 
 ```javascript
 var publish = require("fluid-publish");
@@ -231,6 +231,38 @@ publish.standard();
             </td>
             <td>
                 "git checkout -- ${package}"
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>vcTagCmd</code>
+            </td>
+            <td>
+                The CLI to execute which creates the version control tag.
+                <ul>
+                    <li>
+                        <code>${version}</code> will be substituted with the version from the package.json file.
+                    </li>
+                </ul>
+            </td>
+            <td>
+                "git tag -a v${version} -m 'Tagging the ${version} release'"
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>pushVCTagCmd</code>
+            </td>
+            <td>
+                The CLI to execute which publishes the version control tag.
+                <ul>
+                    <li>
+                        <code>${version}</code> will be substituted with the version from the package.json file.
+                    </li>
+                </ul>
+            </td>
+            <td>
+                "git push upstream v${version}"
             </td>
         </tr>
         <tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-publish",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A command line tool and node module that can be used to simplify the process of publishing a module to NPM. This is particularly useful for creating development releases, e.g. nightly or continuous integration releases.",
   "main": "publish.js",
   "engines": {
@@ -47,6 +47,8 @@
     "versionCmd": "npm version --no-git-tag-version ${version}",
     "distTagCmd": "npm dist-tag add ${packageName}@${version} ${tag}",
     "cleanCmd": "git checkout -- package.json",
+    "vcTagCmd": "git tag -a v${version} -m 'Tagging the ${version} release'",
+    "pushVCTagCmd": "git push upstream v${version}",
     "devVersion": "${version}-${preRelease}.${timestamp}.${revision}",
     "devTag": "dev",
     "moduleRoot": ""

--- a/publish.js
+++ b/publish.js
@@ -14,8 +14,6 @@ https://github.com/fluid-project/first-discovery-server/raw/master/LICENSE.txt
 
 var publish = {};
 var path = require("path");
-var pkgPath = path.join(__dirname, "package.json");
-var pkg = require(pkgPath);
 var extend = require("extend");
 
 // execSync  and log are added to the exported "publish" namespace so they can
@@ -27,6 +25,21 @@ publish.log = console.log;
 // When version node.js 4.x.x is supported this can be replaced by native support.
 var es6Template = require("es6-template-strings");
 
+/**
+ * Returns the contents of a package.json file as JSON object
+ *
+ * @param moduleRoot {String} - the path to the root where the package.json is
+ *                              located. Will use process.cwd() by default.
+ * @returns {Object} - returns the contents of the package.json file as a JSON
+ *                     object.
+ */
+publish.getPkg = function (moduleRoot) {
+    moduleRoot = moduleRoot || process.cwd();
+    var modulePkgPath = path.join(moduleRoot, "package.json");
+    return require(modulePkgPath);
+};
+
+var pkg = publish.getPkg(__dirname);
 var defaults = pkg.defaultOptions;
 
 /**
@@ -52,21 +65,6 @@ publish.getCLIOpts = function () {
         }
     });
     return opts;
-};
-
-
-/**
- * Returns the contents of a package.json file as JSON object
- *
- * @param moduleRoot {String} - the path to the root where the package.json is
- *                              located. Will use process.cwd() by default.
- * @returns {Object} - returns the contents of the package.json file as a JSON
- *                     object.
- */
-publish.getPkg = function (moduleRoot) {
-    moduleRoot = moduleRoot || process.cwd();
-    var modulePkgPath = path.join(moduleRoot, "package.json");
-    return require(modulePkgPath);
 };
 
 /**

--- a/publish.js
+++ b/publish.js
@@ -144,17 +144,17 @@ publish.checkChanges = function (options) {
  * @param cmdTemplate {String} - A string template of the command to execute.
  *                               Can provide tokens in the form ${tokenName}
  * @param values {Object} - the tokens and their replacement.
-                            e.g. {tokenName: "value to insert"}
+ *                          e.g. {tokenName: "value to insert"}
  * @param isTest {Boolean} - indicates if this is a test run or not
  */
- publish.execSyncFromTemplate = function (cmdTemplate, cmdValues, isTest) {
-     var cmdStr = es6Template(cmdTemplate, cmdValues);
-     if (isTest) {
-         publish.log("command: " + cmdStr);
-     } else {
-         publish.execSync(cmdStr);
-     }
- };
+publish.execSyncFromTemplate = function (cmdTemplate, cmdValues, isTest) {
+    var cmdStr = es6Template(cmdTemplate, cmdValues);
+    if (isTest) {
+        publish.log("command: " + cmdStr);
+    } else {
+        publish.execSync(cmdStr);
+    }
+};
 
 /**
  * Updates the package.json version to the specified version

--- a/publish.js
+++ b/publish.js
@@ -188,7 +188,8 @@ publish.getDevVersion = function (moduleVersion, options) {
         version: moduleVersion,
         preRelease: preRelease,
         timestamp: timestamp,
-        revision: revision
+        // ensure that there are no leading or trailing whitespace characters
+        revision: revision.toString().trim()
     });
     return newStr;
 };


### PR DESCRIPTION
https://issues.fluidproject.org/browse/FLUID-5795

also added a fix for
https://issues.fluidproject.org/browse/FLUID-5798