### PR TITLE
feat(): skip checkChanges publish dev and standard

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -293,8 +293,15 @@ publish.dev = function (isTest, options) {
     // running this module.
     var modulePkg = publish.getPkg(opts.moduleRoot);
 
+    var checkChange = options.checkChanges;
+    if (checkChange === undefined) {
+        checkChange = true;
+    }
+
     // Ensure no uncommitted changes
-    publish.checkChanges(opts);
+    if (checkChange) {
+        publish.checkChanges(opts);
+    }
 
     var devVersion = publish.getDevVersion(modulePkg.version, opts);
 
@@ -326,8 +333,15 @@ publish.standard = function (isTest, options) {
     // running this module.
     var modulePkg = publish.getPkg(opts.moduleRoot);
 
+    var checkChange = options.checkChanges;
+    if (checkChange === undefined) {
+        checkChange = true;
+    }
+
     // Ensure no uncommitted changes
-    publish.checkChanges(opts);
+    if (checkChange) {
+       publish.checkChanges(opts);
+    }
 
     // create version control tag
     publish.tagVC (isTest, modulePkg.version, opts);

--- a/tests/publishTests.js
+++ b/tests/publishTests.js
@@ -454,3 +454,46 @@ publishFixture.forEach(function (fixture) {
 
     removeStubs(publish, toStub);
 });
+
+var skipChanges = [{
+    isTest: false,
+    options: {
+        "changesCmd": "dry run get changes",
+        "rawTimestampCmd": "dry run get rawTimestamp",
+        "revisionCmd": "dry run get revision",
+        "packCmd": "dry run pack",
+        "checkChanges": false,
+        "publishCmd": "dry run publish",
+        "versionCmd": "dry run version",
+        "distTagCmd": "dry run set tag",
+        "cleanCmd": "dry run clean",
+        "vcTagCmd": "dry run vc tag",
+        "pushVCTagCmd": "dry run push vc tag",
+        "devVersion": "dry run ${version}-${preRelease}.${timestamp}.${revision}",
+        "devTag": "dry run dev",
+        "moduleRoot": __dirname
+    }
+}];
+
+// publish.skipcheckchanges
+console.log("\n*** publish.skipcheckchanges ***");
+
+skipChanges.forEach(function (fixture) {
+    // test check changes dev
+    var toStub = ["checkChanges", "getDevVersion", "setVersion", "pubImpl", "tag", "clean"];
+    var stub = createStubs(publish, toStub);
+
+    publish.dev(fixture.isTest, fixture.options);
+
+    assert(stub.checkChanges.notCalled, "checkChanges not should have been called");
+    removeStubs(publish, toStub);
+
+    // test check changes standard
+    var toStub = ["checkChanges", "tagVC", "pubImpl"];
+    var stub = createStubs(publish, toStub);
+
+    publish.standard(fixture.isTest, fixture.options);
+
+    assert(stub.checkChanges.notCalled, "checkChanges not should have been called");
+    removeStubs(publish, toStub);
+});


### PR DESCRIPTION
- Skip called Publish.checkchanges() to dev and standard this need in case project alter package.json before of publish