### PR TITLE
FLUID-6270: Adding ability to name the dev release

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,14 +313,10 @@ publish.standard();
         </tr>
         <tr>
             <td>
-                <code>versionMetadata</code>
+                <code>devName</code>
             </td>
             <td>
-                <p>
-                    Any metadata to be appended to the version. This will be appended with a "+" (e.g. 3.0.0.dev+branchX). If a dev release is generated from a branch other than "master", the branch name will be used as the metadata, if <code>versionMetadata</code> is not supplied.
-                </p>
-
-                <p><em><strong>NOTE</strong>: metadata is only applied to Dev Releases.</em></p>
+                An optional dev release name to be appended to the version. This will be separated by a "." (e.g. with "branchX" as the dev release name. 3.0.0.dev.20151015T131223Z.039d221.branchX). When a dev release is generated from a branch other than "master", the branch name will automatically be used as the dev release name, if <code>devName</code> is not supplied.
             </td>
             <td>
                 ""

--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ publish.standard();
         </tr>
         <tr>
             <td>
+                <code>branchCmd</code>
+            </td>
+            <td>
+                The CLI to execute which returns the name of the current branch.
+            </td>
+            <td>
+                "git rev-parse --abbrev-ref HEAD"
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <code>packCmd</code>
             </td>
             <td>
@@ -298,6 +309,21 @@ publish.standard();
             </td>
             <td>
                 "${version}.${timestamp}.${revision}"
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>versionMetadata</code>
+            </td>
+            <td>
+                <p>
+                    Any metadata to be appended to the version. This will be appended with a "+" (e.g. 3.0.0.dev+branchX). If a dev release is generated from a branch other than "master", the branch name will be used as the metadata, if <code>versionMetadata</code> is not supplied.
+                </p>
+
+                <p><em><strong>NOTE</strong>: metadata is only applied to Dev Releases.</em></p>
+            </td>
+            <td>
+                ""
             </td>
         </tr>
         <tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-publish",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A command line tool and node module that can be used to simplify the process of publishing a module to NPM. This is particularly useful for creating development releases, e.g. nightly or continuous integration releases.",
   "main": "publish.js",
   "engines": {
@@ -44,6 +44,7 @@
     "checkRemoteCmd": "git ls-remote --exit-code ${remote}",
     "rawTimestampCmd": "git show -s --format=%ct HEAD",
     "revisionCmd": "git rev-parse --verify --short HEAD",
+    "branchCmd": "git rev-parse --abbrev-ref HEAD",
     "packCmd": "npm pack",
     "publishCmd": "npm publish",
     "publishDevCmd": "npm publish --tag ${devTag}",
@@ -52,6 +53,7 @@
     "vcTagCmd": "git tag -a v${version} -m 'Tagging the ${version} release'",
     "pushVCTagCmd": "git push ${remote} v${version}",
     "devVersion": "${version}-${preRelease}.${timestamp}.${revision}",
+    "versionMetadata": "",
     "devTag": "dev",
     "remoteName": "upstream",
     "moduleRoot": "",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vcTagCmd": "git tag -a v${version} -m 'Tagging the ${version} release'",
     "pushVCTagCmd": "git push ${remote} v${version}",
     "devVersion": "${version}-${preRelease}.${timestamp}.${revision}",
-    "versionMetadata": "",
+    "devName": "",
     "devTag": "dev",
     "remoteName": "upstream",
     "moduleRoot": "",

--- a/publish.js
+++ b/publish.js
@@ -199,11 +199,11 @@ publish.setVersion = function (version, options) {
 
 /**
  * Calculates the current dev version of the package.
- * Will include version metadata if run on a branch other than master, or if
- * the versionMetadata option is provided.
+ * Will include dev version name if run on a branch other than master, or if
+ * the devName option is provided.
  *
  * @param moduleVersion {String} - The version of the module (e.g. X.x.x)
- * @param options {Object} - e.g. {"rawTimestampCmd": "git show -s --format=%ct HEAD", "revisionCmd": "git rev-parse --verify --short HEAD", "branchCmd": "git rev-parse --abbrev-ref HEAD", "devVersion": "${version}-${preRelease}.${timestamp}.${revision}", "versionMetadata": "", "devTag": "dev"}
+ * @param options {Object} - e.g. {"rawTimestampCmd": "git show -s --format=%ct HEAD", "revisionCmd": "git rev-parse --verify --short HEAD", "branchCmd": "git rev-parse --abbrev-ref HEAD", "devVersion": "${version}-${preRelease}.${timestamp}.${revision}", "devName": "", "devTag": "dev"}
  * @returns {String} - the current dev version number
  */
 publish.getDevVersion = function (moduleVersion, options) {
@@ -219,8 +219,8 @@ publish.getDevVersion = function (moduleVersion, options) {
         revision: revision
     });
 
-    if (branch !== "master" || options.versionMetadata) {
-        newStr = newStr + "+" + (options.versionMetadata || branch);
+    if (branch !== "master" || options.devName) {
+        newStr = newStr + "." + (options.devName || branch);
     }
 
     return newStr;

--- a/tests/publishTests.js
+++ b/tests/publishTests.js
@@ -285,26 +285,67 @@ console.log("\n*** publish.getDevVersion ***");
 var getDevVersionFixture = [{
     rawTimestampCmd: "get raw timestamp",
     revisionCmd: "get revision",
+    branchCmd: "get branch",
     devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
+    versionMetadata: "",
     devTag: "test",
     moduleVersion: "1.2.3",
     expectedVersion: "1.2.3-test.20151015T131223Z.039d221",
     returnedTimestamp: 1444914743,
-    returnedRevision: "039d221"
+    returnedRevision: "039d221",
+    returnedBranch: "master"
+}, {
+    rawTimestampCmd: "get raw timestamp",
+    revisionCmd: "get revision",
+    branchCmd: "get branch",
+    devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
+    versionMetadata: "master-metadata",
+    devTag: "test",
+    moduleVersion: "1.2.3",
+    expectedVersion: "1.2.3-test.20151015T131223Z.039d221+master-metadata",
+    returnedTimestamp: 1444914743,
+    returnedRevision: "039d221",
+    returnedBranch: "master"
+}, {
+    rawTimestampCmd: "get raw timestamp",
+    revisionCmd: "get revision",
+    branchCmd: "get branch",
+    devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
+    versionMetadata: "",
+    devTag: "test",
+    moduleVersion: "1.2.3",
+    expectedVersion: "1.2.3-test.20151015T131223Z.039d221+fluid-xxxx",
+    returnedTimestamp: 1444914743,
+    returnedRevision: "039d221",
+    returnedBranch: "fluid-xxxx"
+}, {
+    rawTimestampCmd: "get raw timestamp",
+    revisionCmd: "get revision",
+    branchCmd: "get branch",
+    devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
+    versionMetadata: "branch-metadata",
+    devTag: "test",
+    moduleVersion: "1.2.3",
+    expectedVersion: "1.2.3-test.20151015T131223Z.039d221+branch-metadata",
+    returnedTimestamp: 1444914743,
+    returnedRevision: "039d221",
+    returnedBranch: "fluid-xxxx"
 }];
 
 getDevVersionFixture.forEach(function (fixture) {
-    console.log("getDevVersion test - rawTimestampCmd: " + fixture.rawTimestampCmd + " revisionCmd: " + fixture.revisionCmd + " devVersion: " + fixture.devVersion);
+    console.log("getDevVersion test - rawTimestampCmd: " + fixture.rawTimestampCmd + " revisionCmd: " + fixture.revisionCmd + " branch: " + fixture.returnedBranch + " devVersion: " + fixture.devVersion + " versionMetadata: " + fixture.versionMetadata);
 
     var exec = sinon.stub(publish, "execSync");
     exec.onFirstCall().returns(fixture.returnedTimestamp);
     exec.onSecondCall().returns(fixture.returnedRevision);
+    exec.onThirdCall().returns(fixture.returnedBranch);
 
     var result = publish.getDevVersion(fixture.moduleVersion, fixture);
 
-    assert(exec.calledTwice, "execSync should have been called twice");
-    assert(exec.calledWith(fixture.rawTimestampCmd), "first execSync should have been called with: " + fixture.rawTimestampCmd);
-    assert(exec.calledWith(fixture.revisionCmd), "second execSync should have been called with: " + fixture.revisionCmd);
+    assert.equal(exec.callCount, 3, "execSync should have been called three times");
+    assert(exec.getCall(0).calledWith(fixture.rawTimestampCmd), "first execSync should have been called with: " + fixture.rawTimestampCmd);
+    assert(exec.getCall(1).calledWith(fixture.revisionCmd), "second execSync should have been called with: " + fixture.revisionCmd);
+    assert(exec.getCall(2).calledWith(fixture.branchCmd), "third execSync should have been called with: " + fixture.branchCmd);
     assert.equal(result, fixture.expectedVersion, "Expected version: " + fixture.expectedVersion + " actual: " + result);
 
     // remove execSync stub
@@ -449,6 +490,7 @@ var publishFixture = [{
         "checkRemoteCmd": "dry run check remote",
         "rawTimestampCmd": "dry run get rawTimestamp",
         "revisionCmd": "dry run get revision",
+        "branchCmd": "dry run get branch",
         "packCmd": "dry run pack",
         "publishCmd": "dry run publish",
         "publishDevCmd": "dry run npm publish dev",
@@ -457,6 +499,7 @@ var publishFixture = [{
         "vcTagCmd": "dry run vc tag",
         "pushVCTagCmd": "dry run push vc tag",
         "devVersion": "dry run ${version}-${preRelease}.${timestamp}.${revision}",
+        "versionMetadata": "dry run metadata",
         "devTag": "dry run dev",
         "remoteName": "dry run remote",
         "moduleRoot": __dirname,
@@ -474,6 +517,7 @@ var publishFixture = [{
         "checkRemoteCmd": "check remote",
         "rawTimestampCmd": "get rawTimestamp",
         "revisionCmd": "get revision",
+        "branchCmd": "get branch",
         "packCmd": "pack",
         "publishCmd": "publish",
         "publishDevCmd": "publish dev",
@@ -482,6 +526,7 @@ var publishFixture = [{
         "vcTagCmd": "vc tag",
         "pushVCTagCmd": "push vc tag",
         "devVersion": "${version}-${preRelease}.${timestamp}.${revision}",
+        "versionMetadata": "metadata",
         "devTag": "dev",
         "remoteName": "remote",
         "moduleRoot": __dirname,
@@ -508,7 +553,7 @@ publishFixture.forEach(function (fixture) {
     var toStub = ["checkChanges", "getDevVersion", "setVersion", "pubImpl", "clean"];
     var stub = createStubs(publish, toStub);
     var moduleVersion = modulePackage.version;
-    var devVersion = moduleVersion + "-testVersion";
+    var devVersion = moduleVersion + "-testVersion+metadata";
 
     stub.getDevVersion.returns(devVersion);
 

--- a/tests/publishTests.js
+++ b/tests/publishTests.js
@@ -287,7 +287,7 @@ var getDevVersionFixture = [{
     revisionCmd: "get revision",
     branchCmd: "get branch",
     devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
-    versionMetadata: "",
+    devName: "",
     devTag: "test",
     moduleVersion: "1.2.3",
     expectedVersion: "1.2.3-test.20151015T131223Z.039d221",
@@ -299,10 +299,10 @@ var getDevVersionFixture = [{
     revisionCmd: "get revision",
     branchCmd: "get branch",
     devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
-    versionMetadata: "master-metadata",
+    devName: "master-dev",
     devTag: "test",
     moduleVersion: "1.2.3",
-    expectedVersion: "1.2.3-test.20151015T131223Z.039d221+master-metadata",
+    expectedVersion: "1.2.3-test.20151015T131223Z.039d221.master-dev",
     returnedTimestamp: 1444914743,
     returnedRevision: "039d221",
     returnedBranch: "master"
@@ -311,10 +311,10 @@ var getDevVersionFixture = [{
     revisionCmd: "get revision",
     branchCmd: "get branch",
     devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
-    versionMetadata: "",
+    devName: "",
     devTag: "test",
     moduleVersion: "1.2.3",
-    expectedVersion: "1.2.3-test.20151015T131223Z.039d221+fluid-xxxx",
+    expectedVersion: "1.2.3-test.20151015T131223Z.039d221.fluid-xxxx",
     returnedTimestamp: 1444914743,
     returnedRevision: "039d221",
     returnedBranch: "fluid-xxxx"
@@ -323,17 +323,17 @@ var getDevVersionFixture = [{
     revisionCmd: "get revision",
     branchCmd: "get branch",
     devVersion: "${version}-${preRelease}.${timestamp}.${revision}",
-    versionMetadata: "branch-metadata",
+    devName: "branch-dev",
     devTag: "test",
     moduleVersion: "1.2.3",
-    expectedVersion: "1.2.3-test.20151015T131223Z.039d221+branch-metadata",
+    expectedVersion: "1.2.3-test.20151015T131223Z.039d221.branch-dev",
     returnedTimestamp: 1444914743,
     returnedRevision: "039d221",
     returnedBranch: "fluid-xxxx"
 }];
 
 getDevVersionFixture.forEach(function (fixture) {
-    console.log("getDevVersion test - rawTimestampCmd: " + fixture.rawTimestampCmd + " revisionCmd: " + fixture.revisionCmd + " branch: " + fixture.returnedBranch + " devVersion: " + fixture.devVersion + " versionMetadata: " + fixture.versionMetadata);
+    console.log("getDevVersion test - rawTimestampCmd: " + fixture.rawTimestampCmd + " revisionCmd: " + fixture.revisionCmd + " branch: " + fixture.returnedBranch + " devVersion: " + fixture.devVersion + " devName: " + fixture.devName);
 
     var exec = sinon.stub(publish, "execSync");
     exec.onFirstCall().returns(fixture.returnedTimestamp);
@@ -499,7 +499,7 @@ var publishFixture = [{
         "vcTagCmd": "dry run vc tag",
         "pushVCTagCmd": "dry run push vc tag",
         "devVersion": "dry run ${version}-${preRelease}.${timestamp}.${revision}",
-        "versionMetadata": "dry run metadata",
+        "devName": "dry run devName",
         "devTag": "dry run dev",
         "remoteName": "dry run remote",
         "moduleRoot": __dirname,
@@ -526,7 +526,7 @@ var publishFixture = [{
         "vcTagCmd": "vc tag",
         "pushVCTagCmd": "push vc tag",
         "devVersion": "${version}-${preRelease}.${timestamp}.${revision}",
-        "versionMetadata": "metadata",
+        "devName": "devName",
         "devTag": "dev",
         "remoteName": "remote",
         "moduleRoot": __dirname,
@@ -553,7 +553,7 @@ publishFixture.forEach(function (fixture) {
     var toStub = ["checkChanges", "getDevVersion", "setVersion", "pubImpl", "clean"];
     var stub = createStubs(publish, toStub);
     var moduleVersion = modulePackage.version;
-    var devVersion = moduleVersion + "-testVersion+metadata";
+    var devVersion = moduleVersion + "-testVersion+devName";
 
     stub.getDevVersion.returns(devVersion);
 


### PR DESCRIPTION
Provides the ability to add an optional name to the dev release. Typically this will be used to identify a branch other than master that has been used to generate the dev release.

https://issues.fluidproject.org/browse/FLUID-6270