### PR TITLE
FLUID-6340: Sharing stdio for publish process with parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fluid-publish",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "A command line tool and node module that can be used to simplify the process of publishing a module to NPM. This is particularly useful for creating development releases, e.g. nightly or continuous integration releases.",
     "main": "publish.js",
     "engines": {

--- a/publish.js
+++ b/publish.js
@@ -142,17 +142,18 @@ publish.convertToISO8601 = function (timestamp) {
  *                        Can provide tokens in the form ${tokenName}
  * @param {Boolean} isTest - indicates if this is a test run or not. If it is
  *                           a test run, the command will be logged but not executed.
+ * @param {Object} options - provide options to underlying execSync command
  *
  * @return {Buffer|String} - the stdout from the command.
- * @throws {Error} - will contain the entire result from node's child_process.spawnSync()
+ * @throws {Error} - will contain the entire result from node's child_process.execSync() error
  */
-publish.execSyncFromTemplate = function (cmdTemplate, cmdValues, hint, isTest) {
+publish.execSyncFromTemplate = function (cmdTemplate, cmdValues, hint, isTest, options) {
     var cmdStr = es6Template(cmdTemplate, cmdValues);
     publish.log("Executing Command: " + cmdStr);
 
     if (!isTest) {
         try {
-            return publish.execSync(cmdStr);
+            return publish.execSync(cmdStr, options);
         } catch (error) {
             var hintStr = es6Template(hint, cmdValues);
             publish.log("Hint: " + hintStr);
@@ -270,7 +271,7 @@ publish.pubImpl = function (isTest, isDev, options) {
             pubCmd = es6Template(options.otpFlag, {command: pubCmd, otp: options.otp});
         }
 
-        publish.execSyncFromTemplate(pubCmd, options, pubHint);
+        publish.execSyncFromTemplate(pubCmd, options, pubHint, false, {stdio: "inherit"});
     }
 };
 


### PR DESCRIPTION
Provide an options to pass down to execSync so that the publish command can be run with the stdio to be shared with the parent process. This is needed so that the OTP can be passed in directly. The OTP can still be passed in with the `--otp` flag, but in cases where the prepublish scripts take a long time, it may time out and need to be entered again.

https://issues.fluidproject.org/browse/FLUID-6340